### PR TITLE
fix: auth0-js password flow

### DIFF
--- a/src/authentication-flows/social.ts
+++ b/src/authentication-flows/social.ts
@@ -91,7 +91,9 @@ export async function socialAuthCallback({
 
   await setSilentAuthCookies(ctx, controller, doId, state.authParams);
 
-  console.log(state.authParams);
+  if (!state.authParams.redirect_uri) {
+    throw new Error('Redirect URI not defined');
+  }
 
   // TODO: This is quick and dirty.. we should validate the values.
   const redirectUri = new URL(state.authParams.redirect_uri);

--- a/src/authorization-grants/passwordGrant.ts
+++ b/src/authorization-grants/passwordGrant.ts
@@ -9,7 +9,7 @@ export async function passwordGrant(
 ): Promise<TokenResponse | null> {
   const user = ctx.env.userFactory.getInstanceByName(params.username);
 
-  const validatePassword = await user.validatePassword.query(params.password);
+  const validatePassword = await user.validatePassword.mutate(params.password);
 
   if (!validatePassword) {
     throw new Error("Incorrect password");

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -312,7 +312,7 @@ export const userRouter = router({
     }),
   validatePassword: publicProcedure
     .input(z.string())
-    .query(async ({ input, ctx }) => {
+    .mutation(async ({ input, ctx }) => {
       const passwordHash = await ctx.state.storage.get<string>(
         StorageKeys.passwordHash
       );

--- a/src/routes/tsoa/authenticate.ts
+++ b/src/routes/tsoa/authenticate.ts
@@ -1,0 +1,135 @@
+// src/users/usersController.ts
+import { Body, Controller, Post, Request, Route, Tags } from "@tsoa/runtime";
+import { RequestWithContext } from "../../types/RequestWithContext";
+import { getId } from "../../models/User";
+import { getClient } from "../../services/clients";
+import { contentTypes, headers } from "../../constants";
+import { AuthenticationCodeExpiredError, InvalidCodeError, UnauthenticatedError } from "../../errors";
+import randomString from "../../utils/random-string";
+import { hexToBase64 } from "../../utils/base64";
+import { AuthParams } from "../../types";
+
+
+export interface LoginError {
+  error: string;
+  error_description: string;
+}
+
+export interface LoginTicket {
+  login_ticket: string;
+  co_verifier: string;
+  co_id: string;
+}
+
+export interface AuthenticateParams {
+  client_id: string;
+  username: string;
+}
+
+export interface CodeAuthenticateParams extends AuthenticateParams {
+  credential_type: "http://auth0.com/oauth/grant-type/passwordless/otp"
+  realm: "email"
+  otp: string;
+}
+
+export interface PasswordAuthenticateParams extends AuthenticateParams {
+  credential_type: "http://auth0.com/oauth/grant-type/password-realm"
+  realm: "Username-Password-Authentication"
+  password: string;
+}
+
+@Route("co")
+@Tags("authenticate")
+export class AuthenticateController extends Controller {
+  /**
+   * The endpoint used to authenticate using an OTP or a password in auth0
+   * @param body
+   * @param request
+   * @returns
+   */
+  @Post("authenticate")
+  public async authenticate(
+    @Body() body: CodeAuthenticateParams | PasswordAuthenticateParams,
+    @Request() request: RequestWithContext
+  ): Promise<LoginTicket | LoginError> {
+    const { env } = request.ctx
+
+    const client = await getClient(env, body.client_id);
+    if (!client) {
+      throw new Error("Client not found");
+    }
+
+    const user = env.userFactory.getInstanceByName(`${client.tenantId}|${body.username}`);
+
+    let authParams: AuthParams | undefined = {
+      client_id: client.id,
+    }
+
+    try {
+      switch (body.realm) {
+        case "email":
+          authParams = await user.validateAuthenticationCode.mutate(body.otp);
+          break;
+        case "Username-Password-Authentication":
+          await user.validatePassword.mutate(body.password);
+          break;
+        default:
+          throw new Error("Unsupported realm")
+      }
+
+      const coVerifier = randomString(32);
+      const coID = randomString(12);
+
+      const payload = {
+        coVerifier,
+        coID,
+        username: body.username,
+        userId: getId(body.client_id, body.username),
+        authParams,
+      };
+
+      const stateId = env.STATE.newUniqueId().toString();
+      const stateInstance = env.stateFactory.getInstanceById(stateId);
+      await stateInstance.createState.mutate({
+        state: JSON.stringify(payload),
+      });
+
+      this.setHeader(headers.contentType, contentTypes.json);
+      return {
+        login_ticket: hexToBase64(stateId),
+        co_verifier: coVerifier,
+        co_id: coID,
+      };
+    } catch (err: any) {
+      this.setStatus(403);
+      this.setHeader(headers.contentType, contentTypes.json);
+
+      if (err instanceof AuthenticationCodeExpiredError) {
+        return {
+          error: "access_denied",
+          error_description:
+            "The verification code has expired. Please try to login again.",
+        };
+      }
+
+      if (err instanceof InvalidCodeError) {
+        return {
+          error: "access_denied",
+          error_description: "Wrong email or verification code.",
+        };
+      }
+
+      if (err instanceof UnauthenticatedError) {
+        return {
+          error: "access_denied",
+          error_description: "Wrong email or password.",
+        };
+      }
+
+      return {
+        error: "access_denied",
+        error_description: `Server error: ${err.message}`,
+      };
+    }
+  }
+}

--- a/src/routes/tsoa/login.ts
+++ b/src/routes/tsoa/login.ts
@@ -252,7 +252,7 @@ export class LoginController extends Controller {
     );
 
     try {
-      await user.validatePassword.query(loginParams.password);
+      await user.validatePassword.mutate(loginParams.password);
 
       return renderMessage(ctx.env.AUTH_TEMPLATES, this, {
         page_title: "Logged in",

--- a/src/types/AuthParams.ts
+++ b/src/types/AuthParams.ts
@@ -17,7 +17,7 @@ export interface AuthParams {
   client_id: string;
   response_type?: AuthorizationResponseType;
   response_mode?: AuthorizationResponseMode;
-  redirect_uri: string;
+  redirect_uri?: string;
   audience?: string;
   state?: string;
   nonce?: string;

--- a/test/routes/tsoa/authenticate.spec.ts
+++ b/test/routes/tsoa/authenticate.spec.ts
@@ -1,0 +1,139 @@
+import { RequestWithContext } from "../../../src/types/RequestWithContext";
+import { mockedContext } from "../../test-helpers";
+import { AuthenticateController, CodeAuthenticateParams, PasswordAuthenticateParams } from "../../../src/routes/tsoa/authenticate";
+
+describe("Authenticated", () => {
+    describe("password", () => {
+        it("should login using a correct password", async () => {
+            const controller = new AuthenticateController();
+
+            const body: PasswordAuthenticateParams = {
+                client_id: "clientId",
+                username: "test@example.com",
+                password: "Test!",
+                realm: "Username-Password-Authentication",
+                credential_type: "http://auth0.com/oauth/grant-type/password-realm"
+            }
+
+            const logs = [];
+
+            const ctx = mockedContext({
+                stateData: {},
+                logs,
+            });
+
+            const actual = await controller.authenticate(body, {
+                ctx,
+            } as RequestWithContext);
+
+            // Should return something like this
+            // {"login_ticket":"uvfFxiqrv_DxNck4t3W8CtBxzMazNGUu","co_verifier":"fuwh_mhhncJyd3oCPcUs7psX5XIhBgZd","co_id":"oe5nra2nOLZy"}
+
+            if ('error' in actual) {
+                throw new Error('should not return error')
+            }
+
+            expect(typeof actual.login_ticket).toBe('string')
+        });
+
+        it("should send an error if the password is incorrect", async () => {
+            const controller = new AuthenticateController();
+
+            const body: PasswordAuthenticateParams = {
+                client_id: "clientId",
+                username: "test@example.com",
+                password: "Test!",
+                realm: "Username-Password-Authentication",
+                credential_type: "http://auth0.com/oauth/grant-type/password-realm"
+            }
+
+            const logs = [];
+
+            const ctx = mockedContext({
+                stateData: {},
+                userData: {
+                    validatePassword: 'UnauthenticatedError'
+                },
+                logs,
+            });
+
+            const actual = await controller.authenticate(body, {
+                ctx,
+            } as RequestWithContext);
+
+            if (!('error' in actual)) {
+                throw new Error('should return error')
+            }
+
+            expect(controller.getStatus()).toBe(403)
+            expect(JSON.stringify(actual)).toBe(JSON.stringify({ "error": "access_denied", "error_description": "Wrong email or password." }))
+        });
+    });
+
+    describe("code", () => {
+        it("should login using a correct password", async () => {
+            const controller = new AuthenticateController();
+
+            const body: CodeAuthenticateParams = {
+                client_id: "clientId",
+                credential_type: "http://auth0.com/oauth/grant-type/passwordless/otp",
+                otp: "111111",
+                realm: "email",
+                username: "test@example.com"
+            }
+
+            const logs = [];
+
+            const ctx = mockedContext({
+                stateData: {},
+                logs,
+            });
+
+            const actual = await controller.authenticate(body, {
+                ctx,
+            } as RequestWithContext);
+
+            // Should return something like this
+            // {"login_ticket":"uvfFxiqrv_DxNck4t3W8CtBxzMazNGUu","co_verifier":"fuwh_mhhncJyd3oCPcUs7psX5XIhBgZd","co_id":"oe5nra2nOLZy"}
+
+            if ('error' in actual) {
+                throw new Error('should not return error')
+            }
+
+            expect(typeof actual.login_ticket).toBe('string')
+        });
+
+        it("should send an error if the password is incorrect", async () => {
+            const controller = new AuthenticateController();
+
+            const body: CodeAuthenticateParams = {
+                client_id: "clientId",
+                credential_type: "http://auth0.com/oauth/grant-type/passwordless/otp",
+                otp: "000000",
+                realm: "email",
+                username: "test@example.com"
+            }
+
+            const logs = [];
+
+            const ctx = mockedContext({
+                stateData: {},
+                userData: {
+                    validatePassword: 'UnauthenticatedError'
+                },
+                logs,
+            });
+
+            const actual = await controller.authenticate(body, {
+                ctx,
+            } as RequestWithContext);
+
+            if (!('error' in actual)) {
+                throw new Error('should return error')
+            }
+
+            expect(controller.getStatus()).toBe(403)
+            expect(JSON.stringify(actual)).toBe(JSON.stringify({ "error": "access_denied", "error_description": "Wrong email or verification code." }))
+        });
+    });
+});

--- a/test/test-helpers/mocked-context.ts
+++ b/test/test-helpers/mocked-context.ts
@@ -5,14 +5,16 @@ import { mockedR2Bucket } from "./mocked-r2-bucket";
 import { mockedKVStorage } from "./mocked-kv-storage";
 import { MockedTokenFactory } from "./mocked-token-factory";
 import { EmailOptions } from "../../src/services/email";
+import { InvalidCodeError, UnauthenticatedError } from "../../src/errors";
 
 export interface MockedContextParams {
   stateData: { [key: string]: string };
+  userData?: { [key: string]: string | boolean };
   logs?: any[];
 }
 
 export function mockedContext(params?: MockedContextParams): Context<Env> {
-  const { stateData = {}, logs = [] } = params || {};
+  const { stateData = {}, userData = {}, logs = [] } = params || {};
 
   return {
     env: {
@@ -32,7 +34,7 @@ export function mockedContext(params?: MockedContextParams): Context<Env> {
             },
           },
           createState: {
-            mutate: async () => {},
+            mutate: async () => { },
           },
         }),
       },
@@ -46,6 +48,26 @@ export function mockedContext(params?: MockedContextParams): Context<Env> {
           createAuthenticationCode: {
             mutate: async () => ({ code: "123456" }),
           },
+          validatePassword: {
+            mutate: async () => {
+              if (userData.validatePassword === 'UnauthenticatedError') {
+                throw new UnauthenticatedError();
+              }
+
+              return true;
+            },
+          },
+          validateAuthenticationCode: {
+            mutate: async (code) => {
+              if (code === '000000') {
+                throw new InvalidCodeError();
+              }
+
+              return {
+                client_id: 'clientId'
+              };
+            }
+          }
         }),
       },
       TokenFactory: MockedTokenFactory,


### PR DESCRIPTION
Moved a route from the passwordless over to a new authenticate controller as it was use by both passwordless and password flows.

Changed the verifyPassword to mutation instead of a query, as it likely will generate some data (a login ticket and logs).

Added tests for both the code flow and password flow.